### PR TITLE
fix: import motivation.js to enable motivation button

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -3,4 +3,5 @@ import "@hotwired/turbo-rails"
 import "controllers"
 import "@popperjs/core"
 import "bootstrap"
+import "motivation"
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,6 +1,7 @@
 # Pin npm packages by running ./bin/importmap
 
 pin "application"
+pin "motivation"
 pin "@hotwired/turbo-rails", to: "turbo.min.js"
 pin "@hotwired/stimulus", to: "stimulus.min.js"
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"


### PR DESCRIPTION
The motivation popup functionality was broken because motivation.js was never imported into the application.

🤖 Generated with [Claude Code](https://claude.com/claude-code)