### PR TITLE
Fix gallery modal z-index to display above navbars

### DIFF
--- a/app/assets/stylesheets/goals/_show.scss
+++ b/app/assets/stylesheets/goals/_show.scss
@@ -15,14 +15,8 @@
     background-size: 120% auto;
     background-position: top center;
     opacity: 0.2;
-    z-index: 0;
+    z-index: -1;
     pointer-events: none;
-  }
-
-  // Mettre le contenu au-dessus du pattern
-  >* {
-    position: relative;
-    z-index: 1;
   }
 }
 
@@ -480,7 +474,8 @@
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
   display: none;
-  z-index: 3000;
+  z-index: 9999;
+  isolation: isolate;
 }
 
 .gallery-modal.is-visible {
@@ -512,11 +507,18 @@
   position: absolute;
   top: 20px;
   right: 20px;
-  background: none;
+  background: rgba(0, 0, 0, 0.4);
   border: none;
   color: white;
   font-size: 28px;
   cursor: pointer;
+  z-index: 10;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 main {

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -214,20 +214,5 @@
   </div>
 </div>
 
-    <!-- gallerie photo -->
-
-<div
-  class="gallery-modal"
-  data-controller="gallery"
-  data-gallery-target="modal">
-
-  <button class="gallery-close" data-action="gallery#close">✕</button>
-
-  <div class="gallery-content">
-    <% @goal.photos.each do |photo| %>
-      <%= image_tag photo, class: "gallery-image" %>
-    <% end %>
-  </div>
-</div>
 </main>
 </div>


### PR DESCRIPTION
- Remove z-index: 1 from .page-goals children to fix stacking context
- Increase gallery-modal z-index to 9999 to appear above navbars
- Improve close button visibility with background and proper z-index
- Remove duplicate gallery-modal markup

🤖 Generated with [Claude Code](https://claude.com/claude-code)